### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # goalbygoal
-TG bot for efficient communnication between parents and children
+TG bot for efficient communication between parents and children
 
    python:3.11.8-slim-bullseye
    aiogram==2.25.2


### PR DESCRIPTION
## Summary
- fix typo "communnication" -> "communication" in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684319fbee808321b5c0459c4f933508