### PR TITLE
Keep webhook on shutdown

### DIFF
--- a/main.py
+++ b/main.py
@@ -236,9 +236,6 @@ async def on_startup(dp):
     await bot.set_webhook(WEBHOOK_URL)
     logging.info(f"Webhook set to {WEBHOOK_URL}")
 
-async def on_shutdown(dp):
-    await bot.delete_webhook()
-    logging.info("Webhook deleted.")
 
 async def webhook_handler(request):
     try:
@@ -259,7 +256,6 @@ if __name__ == "__main__":
         dispatcher=dp,
         webhook_path=WEBHOOK_PATH,
         on_startup=on_startup,
-        on_shutdown=on_shutdown,
         skip_updates=True,
         host="0.0.0.0",
         port=int(os.environ.get('PORT', 8080)),


### PR DESCRIPTION
## Summary
- remove `on_shutdown` handler so webhook remains
- drop `on_shutdown` from `start_webhook`

## Testing
- `TELEGRAM_TOKEN='123:ABC' WEBHOOK_URL='https://example.com' python main.py` *(fails: DefaultCredentialsError)*

------
https://chatgpt.com/codex/tasks/task_e_68431c38553c8321b1638f0cba1812c4