### PR TITLE
Add individual child task management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # goalbygoal
 TG bot for efficient communication between parents and children
 
+## Нові можливості
+
+- Завдання можна призначати окремо кожній дитині
+- Батьки можуть додавати або видаляти дітей
+- Дитина після приєднання може вказати своє ім'я
+
    python:3.11.8-slim-bullseye
    aiogram==2.25.2
    python-dotenv


### PR DESCRIPTION
## Summary
- allow multiple children per parent and manage them
- add ability to generate invite again or remove a child
- let a child set a name on first join
- update README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684326f6132483218f94d3e07b7b00ca