### PR TITLE
Update documentation and add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+TELEGRAM_TOKEN=your-telegram-bot-token
+WEBHOOK_URL=https://your-domain.com
+GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+# Path to service account JSON if needed
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/creds.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Environment variables
+.env
+.env.*
+!.env.example
+
+# Bytecode cache
+*.pyc
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,59 @@
-# goalbygoal
-TG bot for efficient communication between parents and children
+# GoalByGoal
 
-   python:3.11.8-slim-bullseye
-   aiogram==2.25.2
-   python-dotenv
-   pillow
-   google-cloud-firestore
-   aiohttp
+Telegram bot that helps parents assign simple daily tasks to their children and track completion via photos.
+
+## Features
+
+- **Role selection** – user chooses to act as a parent or child when interacting with the bot.
+- **Invite codes** – parents generate a 6 character code that children use to join the family team.
+- **Task management** – parents select tasks from a predefined list and assign them to all connected children.
+- **Photo confirmation** – children send a photo as proof of task completion. The bot checks the EXIF timestamp to ensure the photo was taken today.
+- **Firestore storage** – user profiles, invites and task data are stored in Google Cloud Firestore.
+- **Webhook support** – the bot is designed to run with a webhook endpoint for Telegram updates.
+
+## Requirements
+
+- Python 3.11
+- Telegram bot token
+- Google Cloud Firestore project and credentials
+
+Required Python packages are listed in `requirements.txt`.
+
+## Configuration
+
+Create a `.env` file using `.env.example` as a template:
+
+```bash
+cp .env.example .env
+```
+
+Set the following environment variables:
+
+- `TELEGRAM_TOKEN` – token of your Telegram bot
+- `WEBHOOK_URL` – base URL where Telegram will send webhooks
+- `GOOGLE_CLOUD_PROJECT` – Firestore project ID
+- `GOOGLE_APPLICATION_CREDENTIALS` – path to service account JSON (if not using other auth methods)
+
+## Running locally
+
+Install dependencies and start the bot:
+
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+The bot will start an aiohttp server and register a webhook at `WEBHOOK_URL`.
+
+## Docker
+
+To run the bot in Docker:
+
+```bash
+docker build -t goalbygoal .
+docker run --env-file .env -p 8080:8080 goalbygoal
+```
+
+## Health check
+
+The container exposes `/health` endpoint which returns `OK` and can be used for monitoring.


### PR DESCRIPTION
## Summary
- document bot features and setup
- add example environment file
- ignore local env files

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6843289700ec8321a37570a620a11316